### PR TITLE
Allow to use 2FA (totp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For v2 urls, simply use the ```/v2/<url>``` form
 #### Init
 
 ```python
-Api42(uid, secret, uidv3, secretv3, username, password, scope='public', redirect_uri='', sleep_on_hourly_limit=False, pre_hook=None, post_hook=None, hook_token=False)
+Api42(uid, secret, uidv3, secretv3, username, password, totp, scope='public', redirect_uri='', sleep_on_hourly_limit=False, pre_hook=None, post_hook=None, hook_token=False)
 ```
 - **uid**: your application's uid
 - **secret**: your application's secret
@@ -45,6 +45,7 @@ Api42(uid, secret, uidv3, secretv3, username, password, scope='public', redirect
 - **secretv3**: your OIDC\_RP\_CLIENT\_SECRET
 - **username**: your username
 - **password**: your password
+- **totp**: your TOTP code (2FA)
 - **scope**: the scope of the fetched token
 - **redirect_uri**: The uri to redirect to after web based authentication
 - **sleep\_on\_hourly\_limit**: defines if the client should sleep if the hourly limit is reached. If not, it returns a 429

--- a/api42/api42.py
+++ b/api42/api42.py
@@ -31,13 +31,14 @@ class Api42:
         def __init__(self, message="An error happened durign token fetch"):
             super().__init__(message)
 
-    def __init__(self, uid='', secret='', uidv3='', secretv3='', username='', password='', scope='public', redirect_uri='', sleep_on_hourly_limit=False, pre_hook=None, post_hook=None, hook_token=False):
+    def __init__(self, uid='', secret='', uidv3='', secretv3='', username='', password='', totp='', scope='public', redirect_uri='', sleep_on_hourly_limit=False, pre_hook=None, post_hook=None, hook_token=False):
         self.uid = uid
         self.secret = secret
         self.uidv3 = uidv3
         self.secretv3 = secretv3
         self.username = username
         self.password = password
+        self.totp = totp
         self.scope = scope
         self.base_url = 'https://api.intra.42.fr'
         self.tokenv2_url = 'https://api.intra.42.fr/oauth/token'
@@ -85,6 +86,7 @@ class Api42:
                 'grant_type': 'password',
                 'username': self.username,
                 'password': self.password,
+                'totp': self.totp,
             }
         if self.hook_token and self.pre_hook:
             self.pre_hook('POST', self.tokenv3_url, headers | params)


### PR DESCRIPTION
Without this PR you can't use the client if you have enabled 2FA/TOTP on Keycloak.  
The new `totp` field allows to specify your TOTP code when initializing the client.

Since this lib doesn't handle refresh_token, if the token expire then you will need to generate a new one, with a new TOTP code. I don't have time to add refresh_token logic.