### PR TITLE
Fix regex syntaxwarning _detect_v3 function

### DIFF
--- a/api42/api42.py
+++ b/api42/api42.py
@@ -9,7 +9,7 @@ import re
 def _detect_v3(func):
 
     def wrap(self, url, **kwargs):
-        if (m := re.match("/v3/([\w\-]*)/(v\d)/(.*)", url)):
+        if (m := re.match(r"/v3/([\w\-]*)/(v\d)/(.*)", url)):
             url = f"https://{m.group(1)}.42.fr/api/{m.group(2)}/{m.group(3)}"
             self.v3 = True
             self.token = self.tokenv3


### PR DESCRIPTION
This tiny pull request fixes the `SyntaxWarning: invalid escape sequence '\w'`. This warning pops up when using Python 3.12.1 and running any script using the Api42 class for the first time in a terminal session.